### PR TITLE
Solved "could not open /dev/input/event0, Too many open files"

### DIFF
--- a/replay.c
+++ b/replay.c
@@ -257,6 +257,7 @@ int main(int argc, char *argv[])
 				//should exit...				
 			}    
 			
+			close(fd);
 		}		
 	}
 	else // fopen() returned NULL


### PR DESCRIPTION
"could not open /dev/input/event0, Too many open files"

This error is shown during the replay phase.

Tested on android-15.
